### PR TITLE
fix: Improve verifier

### DIFF
--- a/GithubActionPlugin/scripts/cover-verification.sh
+++ b/GithubActionPlugin/scripts/cover-verification.sh
@@ -12,7 +12,7 @@ echo "Fetching verifier of $CANISTER_ID on $NETWORK"
 wasm=$(echo $resp |sed  -e 's/[;{]/\n\r/g'|sed -e 's/"//g'|grep wasm|awk '/ = (.+)$/{print $4}')
 echo "Fetching canister checksum $CANISTER_ID on $NETWORK"
 resp=$(dfx canister --no-wallet --network $NETWORK info $CANISTER_ID)
-cani=$(echo $resp | awk '/hash: (.+)$/{print $5}')
+cani=$(echo $resp |sed  -e 's/Module/\n\r/g'| grep hash| awk '/hash: (.+)$/{print $3}')
 
 
 echo "Wasm checksum: $wasm"

--- a/GithubActionPlugin/scripts/cover-verification.sh
+++ b/GithubActionPlugin/scripts/cover-verification.sh
@@ -11,9 +11,7 @@ dfx canister --network=$NETWORK call --output=idl cover get_verification_by_cani
 echo "Fetching verifier of $CANISTER_ID on $NETWORK"
 wasm=$(echo $resp |sed  -e 's/[;{]/\n\r/g'|sed -e 's/"//g'|grep wasm|awk '/ = (.+)$/{print $4}')
 echo "Fetching canister checksum $CANISTER_ID on $NETWORK"
-resp=$(dfx canister --no-wallet --network $NETWORK info $CANISTER_ID)
-cani=$(echo $resp |sed  -e 's/Module/\n\r/g'| grep hash| awk '/hash: (.+)$/{print $3}')
-
+cani=$("${BASH_SOURCE%/*}/checksum-canister.sh" $CANISTER_ID $NETWORK)
 
 echo "Wasm checksum: $wasm"
 echo "Module hash: $cani"


### PR DESCRIPTION
## Why?

When verifying canisters with many controllers, the canisterId script did not work properly

## How?

- used canister-checksum.sh inside of cover-verfication.sh 

## Tickets?

- [Ticket 1](the-ticket-url-here)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass

## Demo?
```
GithubActionPlugin/scripts/cover-verification.sh iftvq-niaaa-aaaai-qasga-cai ic   
Fetching verifier of iftvq-niaaa-aaaai-qasga-cai on ic
Fetching canister checksum iftvq-niaaa-aaaai-qasga-cai on ic
Wasm checksum: 0x28c9055a9f847a54812c11b12ec7172fc0c007c9a0e36160d9767b9119a97426
Module hash: 0x28c9055a9f847a54812c11b12ec7172fc0c007c9a0e36160d9767b9119a97426
Status: Verified
```

