### PR TITLE
feat: Secure lambda with access_token (wip)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - production
       - main
-      - fix/*
+      - feat/*
 
 jobs:
   build:
@@ -31,5 +31,6 @@ jobs:
         uses: ./GithubActionPlugin
         # uses: Psychedelic/cover/GithubActionPlugin@main
         with:
+          access_token: ${{ secrets.MY_REPOSITORY_ACCESS_TOKEN }}
           canister_id: ${{ env.cover_canister_id }}
           wasm_path: ".dfx/local/canisters/cover/cover.wasm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test Cover Plugin
+
+on:
+  push:
+    branches:
+      - production
+      - main
+      - feat/*
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    container:
+      image: fleek/dfxrust
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build WASM
+        run: |
+          # HACK: set HOME to get github actions to execute correctly
+          export HOME=/root
+          export PATH="$HOME/.cargo/bin:${PATH}"
+          # Start build
+          # yarn
+          # MODE=PRODUCTION dfx build cover --check
+
+      - name: Cover Validator Plugin
+        uses: ./GithubActionPlugin
+        # uses: Psychedelic/cover/GithubActionPlugin@main
+        with:
+          access_token: ${{ secrets.MY_REPOSITORY_ACCESS_TOKEN }}
+          canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai"
+          wasm_path: ".dfx/local/canisters/cover/cover.wasm"

--- a/GithubActionPlugin/action.yaml
+++ b/GithubActionPlugin/action.yaml
@@ -38,15 +38,17 @@ runs:
 
     - name: "Call Cover SQS Lambda"
       shell: bash
+      if: ${{ inputs.test == "false" }}
       run: |
         # Set URL of the Lambda receiving SQS cover events
         export JSON_PATH="${RUNNER_TEMP}/output.json"
         export COVER_LAMBDA_URL="https://7d6er3977d.execute-api.us-west-2.amazonaws.com/dev/publishSqs"
         jq < $JSON_PATH
-        if [[ "false" == "${{inputs.test}}" ]]; then
-          ret=$(curl -i -X POST ${COVER_LAMBDA_URL} \
-            -H "Content-Type: application/json"\
-            -H "Authorized: ${{github.token}}" \
-            -d "@$JSON_PATH")
-        fi
+        ret=$(curl -i -X POST ${COVER_LAMBDA_URL} \
+          -H "Content-Type: application/json"\
+          -H "Authorized: ${{github.token}}" \
+          -d "@$JSON_PATH")
+        status=$?
+        echo "============================================"
+        echo "Status: $status"
         echo "Sent to ${COVER_LAMBDA_URL} ${ret}"

--- a/GithubActionPlugin/action.yaml
+++ b/GithubActionPlugin/action.yaml
@@ -11,6 +11,10 @@ inputs:
   wasm_path:
     description: "Path to the generated wasm file"
     required: true
+  test:
+    description: "Set to true to block sending requests to Cover backend."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -20,9 +24,10 @@ runs:
       run: |
         source ${GITHUB_ACTION_PATH}/scripts/utils.sh
         export JSON_PATH="${RUNNER_TEMP}/output.json"
+        jset access_token ${{ inputs.access_token }}
+        jset canister_id ${{ inputs.canister_id }}
         jset github_job $GITHUB_RUN_ID
         jset created_at $(timestamp)
-        jset canister_id ${{ inputs.canister_id }}
         jset git_ref $GITHUB_REF
         jset git_sha $GITHUB_SHA
         jset git_repo $GITHUB_REPOSITORY
@@ -38,8 +43,10 @@ runs:
         export JSON_PATH="${RUNNER_TEMP}/output.json"
         export COVER_LAMBDA_URL="https://7d6er3977d.execute-api.us-west-2.amazonaws.com/dev/publishSqs"
         jq < $JSON_PATH
-        ret=$(curl -i -X POST ${COVER_LAMBDA_URL} \
-          -H "Content-Type: application/json"\
-          -H "Authorized: ${{github.token}}" \
-          -d "@$JSON_PATH")
+        if [[ "false" == "${{inputs.test}}" ]]; then
+          ret=$(curl -i -X POST ${COVER_LAMBDA_URL} \
+            -H "Content-Type: application/json"\
+            -H "Authorized: ${{github.token}}" \
+            -d "@$JSON_PATH")
+        fi
         echo "Sent to ${COVER_LAMBDA_URL} ${ret}"

--- a/GithubActionPlugin/action.yaml
+++ b/GithubActionPlugin/action.yaml
@@ -2,6 +2,9 @@ name: "Data for Cover"
 description: "Collect Snapshot Data for Cover Canister"
 
 inputs:
+  access_token:
+    description: "Github Access Token"
+    required: true
   canister_id:
     description: "Id of the canister"
     required: true

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ jobs:
       - name: Cover Validator Plugin
         uses: Psychedelic/cover/GithubActionPlugin@main
         with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
           canister_id: "iftvq-niaaa-aaaai-qasga-cai"
           wasm_path: ".dfx/local/canisters/cover/cover.wasm"
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,20 @@ If you are Cover developer, please read the [Developer Readme](./README-dev.md)
 
 ## Getting started 🤔
 
-### Create Build Action 
+### Preparing Access Token 
+
+To use the cover plugin we need to verify if you are the owner of the canister. We do it using 
+Github Access Tokens. Here is a [tutorial](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+for creating an access token. 
+The cover plugin needs the `repo` scope enabled. 
+
+Once you have generated your access token, you can add it to your repository from the Settings / Secrets page. 
+You can create a repository secret called something like `MY_ACCESS_TOKEN` and insert the access token value there. You
+
+Now we are ready to create a build job. 
+
+
+### Create Build Job
 
 Inside of your canister repo create a directory `.github/workflows/` and add a `myBuild.yml` file,
 with the following content. To see a full build example see [build.yml](.github/workflows/build.yml)
@@ -58,14 +71,16 @@ jobs:
       - name: Cover Validator Plugin
         uses: Psychedelic/cover/GithubActionPlugin@main
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.MY_ACCESS_TOKEN }}
           canister_id: "iftvq-niaaa-aaaai-qasga-cai"
           wasm_path: ".dfx/local/canisters/cover/cover.wasm"
 ```
 
 Whenever you push your code using `production` or `main` branches, the above workflow will be triggered. 
-If you successfully generated the canister.wasm the [Cover Validation Plugin](./GithubActionPlugin) 
-will call an AWS Lambda Function that will add the validation results to the [Cover canister](https://ic.rocks/principal/iftvq-niaaa-aaaai-qasga-cai)   
+If you successfully generated the `canister.wasm` the [Cover Validation Plugin](./GithubActionPlugin) 
+will call an AWS Lambda Function that will add the validation results to the [Cover canister](https://ic.rocks/principal/iftvq-niaaa-aaaai-qasga-cai)
+
+Note that if the provided access token does not have access to this repository, the request will be rejected.
 
 ### Build Canister
 

--- a/serverless/app/package.json
+++ b/serverless/app/package.json
@@ -29,11 +29,12 @@
     "@middy/http-json-body-parser": "^1.5.2",
     "@middy/sqs-json-body-parser": "^2.5.3",
     "@middy/sqs-partial-batch-failure": "^2.5.3",
+    "@octokit/request": "^5.6.2",
+    "ansi-regex": "^5.0.1",
     "cross-fetch": "^3.1.4",
     "source-map-support": "^0.5.19",
     "uuid": "^8.3.2",
-    "yarn": "^1.22.17",
-    "ansi-regex": "^5.0.1"
+    "yarn": "^1.22.17"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.71",

--- a/serverless/app/serverless.yml
+++ b/serverless/app/serverless.yml
@@ -80,14 +80,14 @@ functions:
       - http:
           path: /publishSqs
           method: POST
-  # consume:
-  #   timeout: 10
-  #   memorySize: 128
-  #   handler: src/functions/canister/consume/handler.main
-  #   events:
-  #     - http:
-  #         path: /consume
-  #         method: GET
+  consume:
+    timeout: 10
+    memorySize: 128
+    handler: src/functions/canister/consume/handler.main
+    events:
+      - http:
+          path: /consume
+          method: GET
 resources:
   - Resources:
       CoverQueue:

--- a/serverless/app/src/functions/canister/consume/handler.ts
+++ b/serverless/app/src/functions/canister/consume/handler.ts
@@ -1,38 +1,20 @@
 import 'source-map-support/register';
-import { formatJSONResponse } from '@libs/apiGateway';
-import { middyfy } from '@libs/lambda';
-import createActor from '@libs/actor';
+import {formatJSONResponse} from '@libs/apiGateway';
+import {middyfy} from '@libs/lambda';
+import {validRepoAccessToken} from "@libs/github";
 
-const executeRequest = (data) => {
-  console.log('Received request json', data);
-  // TODO: add build fargate call
-};
 
-const consume = async () => {
-  const list = [];
-  await createActor()
-    .consume_request({})
-    .then((json) => {
-      if (json.Ok) {
-        // returns a list of requests
-        json.Ok.forEach((data) => {
-          executeRequest(data);
-          list.push(data);
-        });
-      } else {
-        console.log('Error state - no json.Ok');
-        list.push({ error: 'No OK object' });
-      }
-    })
-    .catch((err) => {
-      list.push({ error: 'No OK object' });
-      console.log('Error during call', err);
+// Just a tester lambda
+const consume = async (event: any) => {
+    console.log("Received event", {event});
+
+    const ret = await validRepoAccessToken(event.body);
+    console.log('Returned', ret );
+
+    return formatJSONResponse({
+        message: `Consumed data`,
+        ret
     });
-
-  return formatJSONResponse({
-    message: `Consumed data`,
-    list,
-  });
 };
 
 export const main = middyfy(consume);

--- a/serverless/app/src/functions/canister/publish/index.ts
+++ b/serverless/app/src/functions/canister/publish/index.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import schema from './schema';
 import { handlerPath } from '@libs/handlerResolver';
 

--- a/serverless/app/src/functions/sqs/coverPayload.ts
+++ b/serverless/app/src/functions/sqs/coverPayload.ts
@@ -1,6 +1,7 @@
 import { FromSchema } from 'json-schema-to-ts';
 
 export interface CoverPayloadI {
+  access_token: string;
   canister_id: string;
   created_at: string;
   git_ref: string;
@@ -15,6 +16,9 @@ export interface CoverPayloadI {
 export const CoverSchema = {
   type: 'object',
   properties: {
+    access_token: {
+      type: 'string',
+    },
     canister_id: {
       type: 'string',
     },

--- a/serverless/app/src/libs/github.ts
+++ b/serverless/app/src/libs/github.ts
@@ -1,0 +1,41 @@
+import {request} from "@octokit/request";
+
+// @ts-ignore
+const listUserRepositories = async ({access_token, owner, repo}) => {
+    const ret = await request(// "GET /repos/{owner}/{repo}",
+        "GET /user/repos",
+        {
+            headers: {authorization: `token ${access_token}`},
+            owner,
+            repo
+        });
+    return ret.data;
+}
+
+const filterRepos = (element: any, owner: String, repo: String) =>
+    element.full_name.localeCompare(`${owner}/${repo}`, undefined, {sensitivity: 'accent'}) === 0;
+
+/**
+ * Check if user with access_token has access to git_repo
+ * @param data includes { git_repo, access_token }
+ * @param git_repo of kind "owner/repo"
+ * @param access_token: Personal Access Token from user's Github development settings
+ * @return true if the user has access to the repo
+ */
+const validRepoAccessToken = async (data: { git_repo: String, access_token: String }): Promise<boolean> => {
+    const {git_repo, access_token} = data;
+    const [owner, repo] = git_repo.split("/");
+
+    const userRepos = await listUserRepositories({access_token, owner, repo});
+    const hasRepo = userRepos.filter(el => filterRepos(el, owner, repo));
+
+    // we shall find exactly one repo
+    if (hasRepo.length != 1) return false;
+    const {permissions} = hasRepo[0];
+    const {admin, maintain, push} = permissions as { admin: boolean; maintain: boolean; push: boolean };
+
+    // user must have at least one of these roles
+    return admin || maintain || push;
+}
+
+export {validRepoAccessToken};

--- a/serverless/app/src/libs/github.ts
+++ b/serverless/app/src/libs/github.ts
@@ -2,6 +2,7 @@ import {request} from "@octokit/request";
 
 // @ts-ignore
 const listUserRepositories = async ({access_token, owner, repo}) => {
+    if (!access_token) access_token = "MISSING_TOKEN";
     const ret = await request(// "GET /repos/{owner}/{repo}",
         "GET /user/repos",
         {

--- a/serverless/app/yarn.lock
+++ b/serverless/app/yarn.lock
@@ -1877,6 +1877,48 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/endpoint@^6.0.1":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
+  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
+
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.2.tgz#1aa74d5da7b9e04ac60ef232edd9a7438dcf32d8"
+  integrity sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
+  dependencies:
+    "@octokit/openapi-types" "^11.2.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -4350,6 +4392,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
 deps-sort@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deps-sort/-/deps-sort-2.0.1.tgz#9dfdc876d2bcec3386b6829ac52162cda9fa208d"
@@ -6027,6 +6074,11 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-promise@^2.2.2:
   version "2.2.2"
@@ -9175,6 +9227,11 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## Why?

Anyone could call lambda to fabricate verification entries.

## How?

- Require access_token to be included in plugin requests
- Lambda verifies if the provided access_token has access to the build github repository

## Tickets?

- [Ticket](https://app.shortcut.com/terminalsystems/story/24424/as-cover-developer-i-want-to-secure-access-to-cover-lambda)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass
