### PR TITLE
feat: add time check before register verification

### DIFF
--- a/src/service/time_utils.rs
+++ b/src/service/time_utils.rs
@@ -5,16 +5,18 @@ fn u64_to_utc(time: u64) -> DateTime<Utc> {
     DateTime::<Utc>::from(sys_time)
 }
 
-#[cfg(not(test))]
 pub fn now_to_str() -> String {
+    get_now().to_rfc3339_opts(SecondsFormat::Millis, false)
+}
+
+#[cfg(not(test))]
+pub fn get_now() -> DateTime<Utc> {
     let time = ic_kit::ic::time();
-    let utc = u64_to_utc(time);
-    utc.to_rfc3339_opts(SecondsFormat::Millis, false)
+    u64_to_utc(time)
 }
 
 #[cfg(test)]
-pub fn now_to_str() -> String {
+pub fn get_now() -> DateTime<Utc> {
     let time = 0;
-    let utc = u64_to_utc(time);
-    utc.to_rfc3339_opts(SecondsFormat::Millis, false)
+    u64_to_utc(time)
 }


### PR DESCRIPTION
## Why?

- add time check before register verification

## How?

- add time check  before register new verification just in case the last build fails to update status

## Tickets?

- N/A

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [x] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
